### PR TITLE
Fix hard coded date

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ function App() {
   const dateOptions = { timeZone: 'UTC', month: 'long', day: 'numeric', year: 'numeric' };
 
   const dateFormatter = new Intl.DateTimeFormat('en-US', dateOptions);
-  const dateAsFormattedString = dateFormatter.format(new Date('2019-06-01T00:00:00.000+00:00'));
+  const dateAsFormattedString = dateFormatter.format(new Date());
 
 
   const current_date = dateAsFormattedString


### PR DESCRIPTION
Currently, the date is hard coded to **June 1, 2019** on the app.
```js
const dateAsFormattedString = dateFormatter.format(new Date('2019-06-01T00:00:00.000+00:00'));
```
![Screenshot 2023-10-16 182830](https://github.com/GairikSharma/WeatherApp/assets/66974007/cbe5cd31-c164-4cc5-a8db-51ed4a58dc91)

### Fix:
```js
const dateAsFormattedString = dateFormatter.format(new Date());
```
![image](https://github.com/GairikSharma/WeatherApp/assets/66974007/87288e2f-8cd6-4c89-8cd2-424b0a55c37e)
